### PR TITLE
fix(install): use npm.cmd to bypass PowerShell ExecutionPolicy

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -78,7 +78,7 @@ if (Test-Path (Join-Path $INSTALL_DIR ".git")) {
 # ── Dependances npm ───────────────────────────────────────────────────────────
 Write-Step "Installation des dependances"
 Set-Location $INSTALL_DIR
-npm install --silent
+npm.cmd install --silent
 Write-Ok "Dependances installees"
 
 # ── Lancement ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Corrige `install.ps1` pour appeler `npm.cmd` au lieu de `npm` lors de l'installation des dépendances.
- Sur les PC Windows dont l'`ExecutionPolicy` est `Restricted` (le défaut), le shim `npm.ps1` ne peut pas être chargé, ce qui bloque l'installeur avec une `PSSecurityException` — même quand `npm` fonctionne. `npm.cmd` est un batch non soumis à l'`ExecutionPolicy`, donc l'installation passe y compris sans droits admin.

## Contexte
Remonté par un utilisateur exécutant :
```
irm https://raw.githubusercontent.com/Poudlardo/Allocine2Letterboxd/main/install.ps1 | iex
```
Échec :
```
Impossible de charger le fichier C:\Program Files\nodejs\npm.ps1,
car l'exécution de scripts est désactivée sur ce système.
```

## Verification
- Diff limité à une ligne (`install.ps1`) : `npm install --silent` → `npm.cmd install --silent`.
- Aucune autre dépendance ou logique modifiée.
