### PR TITLE
feat(install): use npm by default, fall back to npm.cmd on script-block

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -78,7 +78,23 @@ if (Test-Path (Join-Path $INSTALL_DIR ".git")) {
 # ── Dependances npm ───────────────────────────────────────────────────────────
 Write-Step "Installation des dependances"
 Set-Location $INSTALL_DIR
-npm.cmd install --silent
+
+# Par defaut on utilise npm ; mais sur les systemes dont l'ExecutionPolicy
+# bloque les scripts .ps1 (Restricted, ou AllSigned sans signature), le shim
+# npm.ps1 ne se charge pas -> PSSecurityException. On bascule alors sur
+# npm.cmd (batch, non soumis a l'ExecutionPolicy) pour rester fonctionnel
+# meme sans droits administrateur.
+$npmExe = "npm"
+try {
+    $policy = Get-ExecutionPolicy -Scope Effective
+} catch {
+    $policy = Get-ExecutionPolicy
+}
+if ($policy -eq "Restricted" -or $policy -eq "AllSigned") {
+    Write-Warn "ExecutionPolicy = $policy : utilisation de npm.cmd pour contourner le blocage des scripts .ps1"
+    $npmExe = "npm.cmd"
+}
+& $npmExe install --silent
 Write-Ok "Dependances installees"
 
 # ── Lancement ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `install.ps1` utilise de nouveau `npm` par défaut pour l'installation des dépendances.
- Détection de l'`ExecutionPolicy` effective : si elle bloque les scripts `.ps1` (`Restricted` ou `AllSigned`), bascule automatiquement sur `npm.cmd` (batch, non soumis à l'`ExecutionPolicy`) avec un avertissement.
- Objectif : robustesse sur les PC verrouillés sans droits admin, tout en gardant le comportement standard (`npm`) partout ailleurs.

## Contexte
Suite à la PR #26 (qui passait inconditionnellement à `npm.cmd`). Comportement attendu :
- PC normal (`RemoteSigned`/`Unrestricted`) → `npm install`
- PC bloqué (`Restricted`/`AllSigned`) → `npm.cmd install` + message d'avertissement

## Verification
- Diff limité au bloc « Installation des dependances » de `install.ps1` (17 insertions, 1 suppression).
- Aucune autre logique modifiée ; fins de ligne LF préservées.
- Pas de PowerShell disponible dans l'environnement de test pour exécuter le script, mais la logique repose sur `Get-ExecutionPolicy -Scope Effective` (API standard).
