### PR TITLE
fix: normalize any profile subpath to membre-Z<ID>/films/ (0 film/0 critique)

### DIFF
--- a/index.js
+++ b/index.js
@@ -576,18 +576,21 @@ function isValidAllocineProfileUrl(url) {
 }
 
 function normalizeUrl(url) {
-    // Si l'URL ne contient pas /films/ à la fin, l'ajouter
-    if (!url.endsWith('/films/') && !url.endsWith('/films')) {
-        // Retirer tout ce qui suit /membre-XXXXX/ si présent
-        let base = url.replace(/\/membre-\w+\/.*$/, '/membre-');
-        // Extraire le membre ID
-        const match = url.match(/\/membre-([A-Z0-9]+)/i);
-        if (match) {
-            base = `https://www.allocine.fr/membre-${match[1]}/`;
-        }
-        url = base + 'films/';
+    // L'utilisateur peut fournir n'importe quelle sous-page de son profil
+    // (racine, /films/, /critiques/films/, /films/envie-de-voir/, ...). On
+    // extrait systematiquement l'ID membre et on reconstruit l'URL racine
+    // /films/ attendue par le reste du scraping. Sans cela, un sous-chemin
+    // comme /critiques/films/ reste en place et les replace(/\/films\/?$/, ...)
+    // produisent des URLs dupliquees (ex. /critiques/critiques/films/).
+    const match = url.match(/\/membre-([A-Z0-9]+)/i);
+    if (match) {
+        return `https://www.allocine.fr/membre-${match[1]}/films/`;
     }
-    // S'assurer que l'URL se termine par /films/
+    // Fallback : si aucun ID membre n'est detecte, on s'assure juste d'un
+    // /films/ final pour limiter la casse.
+    if (!url.endsWith('/films/') && !url.endsWith('/films')) {
+        url = url.replace(/\/$/, '') + '/films/';
+    }
     if (!url.endsWith('/films/')) {
         url = url.replace(/\/films$/, '/films/');
     }


### PR DESCRIPTION
## Summary
- Corrige `normalizeUrl` dans `index.js` pour extraire systématiquement l'ID membre et reconstruire l'URL canonique `membre-<ID>/films/`, quel que soit le sous-chemin fourni par l'utilisateur.

## Problème
Avec une URL d'entrée `https://www.allocine.fr/membre-Z.../critiques/films/` (sous-page critiques), le scraping renvoyait **0 film** et **0 critique**. Cause racine :
- `normalizeUrl` n'ajoutait `/films/` que si l'URL ne finissait pas déjà par `/films/`. Comme `.../critiques/films/` finit par `/films/`, la normalisation était sautée et le segment `/critiques/` restait en place.
- Ensuite `gotoTabCritiques` faisait `replace(/\/films\/?$/, '/critiques/films/')` sur `.../critiques/films/` → `.../critiques/critiques/films/` (URL dupliquée, introuvable).
- `scrapeAllFilms` scrapait `.../critiques/films/` au lieu de `.../films/` → 0 film.

Log observé :
```
📝 Navigating to reviews tab: https://www.allocine.fr/membre-Z.../critiques/critiques/films/
🔍 Waiting for review blocks to load...
   ℹ️ Aucune critique trouvée pour ce profil
```

## Comportement après correction
Toutes ces entrées sont normalisées vers `membre-<ID>/films/` :
- `membre-Z<ID>/` (racine)
- `membre-Z<ID>/films/`
- `membre-Z<ID>/critiques/films/` ← cas du bug
- `membre-Z<ID>/films/envie-de-voir/`
- `membre-Z<ID>` (sans slash final)

Les `replace(/\/films\/?$/, ...)` des scrapers (films, critiques, wishlist) partent alors d'une URL cohérente.

## Verification
- `node --check index.js` : syntaxe OK.
- Tests de la logique `normalizeUrl` sur 6 cas d'entrée (dont `critiques/films/` avec et sans slash final, racine, wishlist) → tous renvoient `membre-<ID>/films/`.
- Diff limité à la fonction `normalizeUrl` (13 insertions, 10 suppressions) ; aucune autre logique touchée.
